### PR TITLE
Refactor `EpsilonSoftPolicy` and related methods to rename `epsilon` …

### DIFF
--- a/core/src/main/kotlin/io/github/kotlinrl/core/Agents.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/Agents.kt
@@ -44,18 +44,17 @@ fun sarsaAgent(
 
 fun expectedSARSAAgent(
     id: String = UUID.randomUUID().toString(),
-    policy: Policy<IntArray, Int>,
+    policy: StochasticPolicy<IntArray, Int>,
     qTable: QTable,
     alpha: Double,
     gamma: Double,
-    stateActionListProvider: StateActionListProvider<IntArray, Int>,
-    policyProbabilities: PolicyProbabilities<IntArray, Int>
+    stateActionListProvider: StateActionListProvider<IntArray, Int>
 ): Agent<IntArray, Int> = agent(id, policy, expectedSARSA(
     qTable = qTable,
     alpha = alpha,
     gamma = gamma,
     stateActionListProvider = stateActionListProvider,
-    policyProbabilities = policyProbabilities
+    policyProbabilities = policy.asPolicyProbabilities(stateActionListProvider)
 ))
 
 fun monteCarloAgent(

--- a/core/src/main/kotlin/io/github/kotlinrl/core/Policies.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/Policies.kt
@@ -46,12 +46,12 @@ fun <State, Action> softMaxPolicy(
 fun <State, Action> epsilonSoftPolicy(
     stateActionListProvider: StateActionListProvider<State, Action>,
     qTable: QFunction<State, Action>,
-    epsilon: ExplorationFactor,
+    explorationFactor: ExplorationFactor,
     rng: Random = Random.Default
 ): ProbabilisticPolicy<State, Action> = EpsilonSoftPolicy(
     stateActionListProvider = stateActionListProvider,
     qTable=qTable,
-    epsilon = epsilon,
+    explorationFactor = explorationFactor,
     rng = rng)
 
 fun <State, Action> StochasticPolicy<State, Action>.asPolicyProbabilities(

--- a/core/src/main/kotlin/io/github/kotlinrl/core/policy/EpsilonSoftPolicy.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/policy/EpsilonSoftPolicy.kt
@@ -2,13 +2,11 @@ package io.github.kotlinrl.core.policy
 
 import io.github.kotlinrl.core.ExplorationFactor
 import io.github.kotlinrl.core.algorithms.QFunction
-import io.github.kotlinrl.core.algorithms.QTable
-import org.jetbrains.kotlinx.multik.ndarray.operations.map
 import kotlin.random.*
 
 class EpsilonSoftPolicy<State, Action>(
     private val qTable: QFunction<State, Action>,
-    private val epsilon: ExplorationFactor,
+    private val explorationFactor: ExplorationFactor,
     private val stateActionListProvider: StateActionListProvider<State, Action>,
     rng: Random
 ) : ProbabilisticPolicy<State, Action>(rng) {
@@ -17,7 +15,7 @@ class EpsilonSoftPolicy<State, Action>(
         val actions = stateActionListProvider(state)
         val greedyAction = qTable.bestAction(state)
         val n = actions.size
-        val epsilon = epsilon()
+        val epsilon = explorationFactor()
 
         return actions.map { action ->
             val prob = if (action == greedyAction) {


### PR DESCRIPTION
…to `explorationFactor`, improve consistency in `expectedSARSAAgent` policy handling, and update `asPolicyProbabilities` usage.