### PR TITLE
Refactor core to replace `Trajectory` with `Transition`, update inter…

### DIFF
--- a/core/src/main/kotlin/io/github/kotlinrl/core/Agents.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/Agents.kt
@@ -1,19 +1,17 @@
 package io.github.kotlinrl.core
 
-
 import java.util.*
 
 typealias Agent<State, Action> = io.github.kotlinrl.core.agent.Agent<State, Action>
-typealias TrajectoryObserver<State, Action> = io.github.kotlinrl.core.agent.TrajectoryObserver<State, Action>
-typealias StepCallback<State, Action> = io.github.kotlinrl.core.agent.StepCallback<State, Action>
+typealias TransitionObserver<State, Action> = io.github.kotlinrl.core.agent.TransitionObserver<State, Action>
+typealias Transition<State, Action> = io.github.kotlinrl.core.agent.Transition<State, Action>
 typealias PolicyAgent<State, Action> = io.github.kotlinrl.core.agent.PolicyAgent<State, Action>
-typealias Trajectory<State, Action> = io.github.kotlinrl.core.agent.Trajectory<State, Action>
 
 fun <State, Action> agent(
     id: String = UUID.randomUUID().toString(),
     policy: Policy<State, Action>,
-    onTrajectory: TrajectoryObserver<State, Action> = TrajectoryObserver { }
-): Agent<State, Action> = PolicyAgent(id, policy, onTrajectory)
+    onTransition: TransitionObserver<State, Action> = TransitionObserver { }
+): Agent<State, Action> = PolicyAgent(id, policy, onTransition)
 
 fun qLearningAgent(
     id: String = UUID.randomUUID().toString(),
@@ -57,30 +55,37 @@ fun expectedSARSAAgent(
     policyProbabilities = policy.asPolicyProbabilities(stateActionListProvider)
 ))
 
+fun nStepSARSAAgent(
+    id: String = UUID.randomUUID().toString(),
+    policy: StochasticPolicy<IntArray, Int>,
+    qTable: QTable,
+    alpha: Double,
+    gamma: Double,
+    n: Int,
+    stateActionListProvider: StateActionListProvider<IntArray, Int>
+): Pair<Agent<IntArray, Int>, EpisodeCallback<IntArray, Int>>  {
+    val learning = nStepSARSA(
+        qTable = qTable,
+        alpha = alpha,
+        gamma = gamma,
+        n = n,
+        policyProbabilities = policy.asPolicyProbabilities(stateActionListProvider)
+    )
+    return agent(id, policy, learning) to learning
+}
+
 fun monteCarloAgent(
     id: String = UUID.randomUUID().toString(),
     policy: Policy<IntArray, Int>
 ): Agent<IntArray, Int> {
-    return agent(id = id, policy = policy) { /* no-op TransitionObserver */ }
+    return agent(id = id, policy = policy)
 }
 
-
-fun <State, Action> Agent<State, Action>.withStepCallback(
-    callback: StepCallback<State, Action>
+fun <State, Action> Agent<State, Action>.withTransitionObserver(
+    onTransition: TransitionObserver<State, Action>
 ): Agent<State, Action> = object : Agent<State, Action> by this {
-    override fun act(state: State): Action {
-        callback.beforeStep(state)
-        val action = this@withStepCallback.act(state)
-        callback.afterStep(state, action)
-        return action
-    }
-}
-
-fun <State, Action> Agent<State, Action>.withTrajectoryObserver(
-    onTrajectory: TrajectoryObserver<State, Action>
-): Agent<State, Action> = object : Agent<State, Action> by this {
-    override fun observe(trajectory: Trajectory<State, Action>) {
-        this@withTrajectoryObserver.observe(trajectory)
-        onTrajectory(trajectory)
+    override fun observe(transition: Transition<State, Action>) {
+        this@withTransitionObserver.observe(transition)
+        onTransition(transition)
     }
 }

--- a/core/src/main/kotlin/io/github/kotlinrl/core/Algorithms.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/Algorithms.kt
@@ -1,32 +1,36 @@
 package io.github.kotlinrl.core
 
-import io.github.kotlinrl.core.agent.TrajectoryObserver
-import io.github.kotlinrl.core.algorithms.ValueFunction
+import io.github.kotlinrl.core.algorithms.dp.PolicyIteration
+import io.github.kotlinrl.core.algorithms.dp.ValueIteration
+import io.github.kotlinrl.core.algorithms.td.TabularTDLearning
+import io.github.kotlinrl.core.env.StepResult
 
 typealias QFunction<State, Action> = io.github.kotlinrl.core.algorithms.QFunction<State, Action>
 typealias QTable = io.github.kotlinrl.core.algorithms.QTable
 typealias VTable = io.github.kotlinrl.core.algorithms.VTable
 typealias PTable = io.github.kotlinrl.core.algorithms.PTable
-typealias ValueIteration<State, Action> = io.github.kotlinrl.core.algorithms.dp.ValueIteration<State, Action>
-typealias PolicyIteration<State, Action> = io.github.kotlinrl.core.algorithms.dp.PolicyIteration<State, Action>
+typealias ValueIteration<State, Action> = ValueIteration<State, Action>
+typealias PolicyIteration<State, Action> = PolicyIteration<State, Action>
 typealias OnPolicyMonteCarloControl<State, Action> = io.github.kotlinrl.core.algorithms.mc.OnPolicyMonteCarloControl<State, Action>
 typealias ConstantAlphaMonteCarloControl<State, Action> = io.github.kotlinrl.core.algorithms.mc.ConstantAlphaMonteCarloControl<State, Action>
 typealias OffPolicyMonteCarloControl<State, Action> = io.github.kotlinrl.core.algorithms.mc.OffPolicyMonteCarloControl<State, Action>
 typealias ExpectedSARSA<State, Action> = io.github.kotlinrl.core.algorithms.td.ExpectedSARSA<State, Action>
 typealias QLearning<State, Action> = io.github.kotlinrl.core.algorithms.td.QLearning<State, Action>
 typealias SARSA<State, Action> = io.github.kotlinrl.core.algorithms.td.SARSA<State, Action>
+typealias NStepSARSA<State, Action> = io.github.kotlinrl.core.algorithms.td.nstep.NStepSARSA<State, Action>
+typealias TabularTDLearning<State, Action> = TabularTDLearning<State, Action>
 
 fun <State, Action> qLearning(
     qTable: QFunction<State, Action>,
     alpha: Double,
     gamma: Double
-): TrajectoryObserver<State, Action> = QLearning(qTable, alpha, gamma)
+): TransitionObserver<State, Action> = QLearning(qTable, alpha, gamma)
 
 fun <State, Action> sarsa(
     qTable: QFunction<State, Action>,
     alpha: Double,
     gamma: Double
-): TrajectoryObserver<State, Action> = SARSA(qTable, alpha, gamma)
+): TransitionObserver<State, Action> = SARSA(qTable, alpha, gamma)
 
 fun <State, Action> expectedSARSA(
     qTable: QFunction<State, Action>,
@@ -34,11 +38,25 @@ fun <State, Action> expectedSARSA(
     gamma: Double,
     stateActionListProvider: StateActionListProvider<State, Action>,
     policyProbabilities: PolicyProbabilities<State, Action>
-): TrajectoryObserver<State, Action> = ExpectedSARSA(
+): TransitionObserver<State, Action> = ExpectedSARSA(
     qTable = qTable,
     alpha = alpha,
     gamma = gamma,
     stateActionListProvider = stateActionListProvider,
+    policyProbabilities = policyProbabilities
+)
+
+fun <State, Action> nStepSARSA(
+    qTable: QFunction<State, Action>,
+    alpha: Double,
+    gamma: Double,
+    n: Int,
+    policyProbabilities: PolicyProbabilities<State, Action>
+): NStepSARSA<State, Action> = NStepSARSA(
+    qTable = qTable,
+    alpha = alpha,
+    gamma = gamma,
+    n = n,
     policyProbabilities = policyProbabilities
 )
 
@@ -53,7 +71,18 @@ fun <State, Action> valueIteration(
 ): Policy<State, Action> = valueIterationPlanner(gamma, theta, vTable, pTable, actionComparator)
     .plan(
         stateActionListProvider = stateActionListProvider,
-        transitionFunction = env::simulateStep
+        transitionFunction = { state, action ->
+            val stepResult: StepResult<State> = env.simulateStep(state, action)
+            Transition(
+                state = state,
+                action = action,
+                reward =  stepResult.reward,
+                nextState = stepResult.state,
+                terminated = stepResult.terminated,
+                truncated = stepResult.truncated,
+                info = stepResult.info
+            )
+        }
     )
 
 fun <State, Action> valueIteration(
@@ -81,7 +110,18 @@ fun <State, Action> policyIteration(
 ): Policy<State, Action> = policyIterationPlanner(gamma, theta, vTable, pTable)
     .plan(
         stateActionListProvider = stateActionListProvider,
-        transitionFunction = env::simulateStep
+        transitionFunction = { state, action ->
+            val stepResult: StepResult<State> = env.simulateStep(state, action)
+            Transition(
+                state = state,
+                action = action,
+                reward =  stepResult.reward,
+                nextState = stepResult.state,
+                terminated = stepResult.terminated,
+                truncated = stepResult.truncated,
+                info = stepResult.info
+            )
+        }
     )
 
 fun policyIteration(

--- a/core/src/main/kotlin/io/github/kotlinrl/core/Env.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/Env.kt
@@ -1,7 +1,7 @@
 package io.github.kotlinrl.core
 
 typealias InitialState<State> = io.github.kotlinrl.core.env.InitialState<State>
-typealias Transition<State> = io.github.kotlinrl.core.env.Transition<State>
+typealias StepResult<State> = io.github.kotlinrl.core.env.StepResult<State>
 typealias Rendering = io.github.kotlinrl.core.env.Rendering
 typealias RenderFrame = io.github.kotlinrl.core.env.Rendering.RenderFrame
 typealias ModelBasedEnv<State, Action, ObservationSpace, ActionSpace> = io.github.kotlinrl.core.env.ModelBasedEnv<State, Action, ObservationSpace, ActionSpace>

--- a/core/src/main/kotlin/io/github/kotlinrl/core/Policies.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/Policies.kt
@@ -1,5 +1,6 @@
 package io.github.kotlinrl.core
 
+import kotlin.math.pow
 import kotlin.random.*
 
 typealias ExplorationFactor = io.github.kotlinrl.core.policy.ExplorationFactor
@@ -62,10 +63,18 @@ fun <State, Action> StochasticPolicy<State, Action>.asPolicyProbabilities(
 
 fun constantEpsilon(factor: Double) = ExplorationFactor { factor }
 
-fun decayingEpsilon(factor: Double, decayRate: Double, minFactor: Double): ExplorationFactor {
+fun decayingEpsilon(
+    factor: Double,
+    decayRate: Double,
+    minFactor: Double,
+    burnInEpisodes: Int = 0
+): ExplorationFactor {
+    var episode = 0
     var epsilon = factor
     return ExplorationFactor {
-        epsilon = (epsilon * decayRate).coerceAtLeast(minFactor)
+        val eps = if (episode < burnInEpisodes) epsilon else
+            (epsilon * decayRate.pow((episode - burnInEpisodes).toDouble())).coerceAtLeast(minFactor)
+        episode++
         epsilon
     }
 }

--- a/core/src/main/kotlin/io/github/kotlinrl/core/Trainers.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/Trainers.kt
@@ -3,6 +3,7 @@ package io.github.kotlinrl.core
 typealias EpisodeTrainer<State, Action> = io.github.kotlinrl.core.train.EpisodeTrainer<State, Action>
 typealias EpisodeCallback<State, Action> = io.github.kotlinrl.core.train.EpisodeCallback<State, Action>
 typealias Trainer = io.github.kotlinrl.core.train.Trainer
+typealias Trajectory<State, Action> = List<Transition<State, Action>>
 typealias TrainingResult = io.github.kotlinrl.core.train.TrainingResult
 typealias Env<State, Action, ObservationSpace, ActionSpace> = io.github.kotlinrl.core.env.Env<State, Action, ObservationSpace, ActionSpace>
 typealias EpisodeStats<State, Action> = io.github.kotlinrl.core.train.EpisodeStats<State, Action>

--- a/core/src/main/kotlin/io/github/kotlinrl/core/Wrappers.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/Wrappers.kt
@@ -135,7 +135,7 @@ class FramePlayer : Application() {
                 style = "-fx-text-fill: white; -fx-font-weight: bold;"
             }
             val timeSlider = Slider(0.0, frames.size - 1.0, 0.0)
-            val fpsSlider = Slider(15.0, 60.0, initialFps.toDouble()).apply {
+            val fpsSlider = Slider(6.0, 60.0, initialFps.toDouble()).apply {
                 majorTickUnit = 15.0
                 minorTickCount = 0
                 isSnapToTicks = true
@@ -193,12 +193,13 @@ class FramePlayer : Application() {
                 (playPauseButton.graphic as SVGPath).content = if (isPlaying) pauseIcon else playIcon
             }
 
+            val availableFps = listOf(6.0, 15.0, 30.0, 45.0, 60.0)
             rewindButton.setOnAction {
-                fpsSlider.value = listOf(15.0, 30.0, 45.0, 60.0).filter { it < fpsSlider.value }.maxOrNull() ?: 15.0
+                fpsSlider.value = availableFps.filter { it < fpsSlider.value }.maxOrNull() ?: 15.0
             }
 
             forwardButton.setOnAction {
-                fpsSlider.value = listOf(15.0, 30.0, 45.0, 60.0).filter { it > fpsSlider.value }.minOrNull() ?: 60.0
+                fpsSlider.value = availableFps.filter { it > fpsSlider.value }.minOrNull() ?: 60.0
             }
 
             stepLeftButton.setOnAction {
@@ -219,8 +220,16 @@ class FramePlayer : Application() {
                 timeLabel.text = formatFrameName(currentFrame, frameFiles)
             }
 
-            val controlRow = HBox(10.0, stepLeftButton, rewindButton, playPauseButton, forwardButton, stepRightButton, timeLabel).apply {
-                alignment = Pos.CENTER_LEFT
+            val buttonRow = HBox(10.0, stepLeftButton, rewindButton, playPauseButton, forwardButton, stepRightButton).apply {
+                alignment = Pos.CENTER
+            }
+
+            val labelRow = HBox(timeLabel).apply {
+                alignment = Pos.CENTER
+            }
+
+            val controlRow = VBox(5.0, buttonRow, labelRow).apply {
+                alignment = Pos.CENTER
                 padding = Insets(10.0)
                 style = "-fx-background-color: rgba(0,0,0,0.6); -fx-background-radius: 10;"
                 isVisible = false
@@ -233,30 +242,32 @@ class FramePlayer : Application() {
                 isVisible = false
             }
 
-            val hideDelay = PauseTransition(Duration.seconds(2.5)).apply {
-                setOnFinished {
-                    controlRow.isVisible = false
-                    sliderRow.isVisible = false
-                }
-            }
-
             val root = StackPane(imageView, VBox(controlRow, sliderRow).apply {
                 alignment = Pos.BOTTOM_CENTER
                 padding = Insets(20.0)
             })
-
-            fun showControls(@Suppress("UNUSED_PARAMETER") e: MouseEvent? = null) {
-                controlRow.isVisible = true
-                sliderRow.isVisible = true
-                hideDelay.stop()
-                hideDelay.playFromStart()
+            fun hideControlsIfNotHovering() {
+                PauseTransition(Duration.millis(150.0)).apply {
+                    setOnFinished {
+                        if (!controlRow.isHover && !sliderRow.isHover && !root.isHover) {
+                            controlRow.isVisible = false
+                            sliderRow.isVisible = false
+                        }
+                    }
+                    play()
+                }
             }
 
-            root.setOnMouseMoved(::showControls)
-            controlRow.setOnMouseEntered { hideDelay.stop() }
-            controlRow.setOnMouseExited { hideDelay.playFromStart() }
-            sliderRow.setOnMouseEntered { hideDelay.stop() }
-            sliderRow.setOnMouseExited { hideDelay.playFromStart() }
+            fun showControls() {
+                controlRow.isVisible = true
+                sliderRow.isVisible = true
+            }
+
+            root.setOnMouseMoved { showControls() }
+            root.setOnMouseExited { hideControlsIfNotHovering() }
+
+            controlRow.setOnMouseExited { hideControlsIfNotHovering() }
+            sliderRow.setOnMouseExited { hideControlsIfNotHovering() }
 
             val scene = Scene(root, width, height)
             val finalStage = Stage()

--- a/core/src/main/kotlin/io/github/kotlinrl/core/agent/Agent.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/agent/Agent.kt
@@ -3,5 +3,5 @@ package io.github.kotlinrl.core.agent
 interface Agent<State, Action> {
     val id: String
     fun act(state: State): Action
-    fun observe(trajectory: Trajectory<State, Action>)
+    fun observe(transition: Transition<State, Action>)
 }

--- a/core/src/main/kotlin/io/github/kotlinrl/core/agent/PolicyAgent.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/agent/PolicyAgent.kt
@@ -1,14 +1,14 @@
 package io.github.kotlinrl.core.agent
 
-import io.github.kotlinrl.core.policy.*
+import io.github.kotlinrl.core.*
 
 class PolicyAgent<State, Action>(
     override val id: String,
     val policy: Policy<State, Action>,
-    val onTrajectory: TrajectoryObserver<State, Action> = TrajectoryObserver {  }
+    val onTransition: TransitionObserver<State, Action> = TransitionObserver { }
 ) : Agent<State, Action> {
 
     override fun act(state: State): Action = policy(state)
 
-    override fun observe(trajectory: Trajectory<State, Action>) = onTrajectory(trajectory)
+    override fun observe(transition: Transition<State, Action>) = onTransition(transition)
 }

--- a/core/src/main/kotlin/io/github/kotlinrl/core/agent/StepCallback.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/agent/StepCallback.kt
@@ -1,6 +1,0 @@
-package io.github.kotlinrl.core.agent
-
-interface StepCallback<State, Action> {
-    fun beforeStep(state: State) { }
-    fun afterStep(state: State, action: Action) { }
-}

--- a/core/src/main/kotlin/io/github/kotlinrl/core/agent/TrajectoryObserver.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/agent/TrajectoryObserver.kt
@@ -1,5 +1,0 @@
-package io.github.kotlinrl.core.agent
-
-fun interface TrajectoryObserver<State, Action> {
-    operator fun invoke(trajectory: Trajectory<State, Action>)
-}

--- a/core/src/main/kotlin/io/github/kotlinrl/core/agent/Transition.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/agent/Transition.kt
@@ -1,11 +1,13 @@
 package io.github.kotlinrl.core.agent
 
-data class Trajectory<State, Action>(
+data class Transition<State, Action>(
     val state: State,
     val action: Action,
     val reward: Double,
     val nextState: State,
     val terminated: Boolean,
     val truncated: Boolean,
-    val info: Map<String, String>
-)
+    val info: Map<String, String> = emptyMap()
+) {
+    val done: Boolean get() = terminated || truncated
+}

--- a/core/src/main/kotlin/io/github/kotlinrl/core/agent/TransitionObserver.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/agent/TransitionObserver.kt
@@ -1,0 +1,5 @@
+package io.github.kotlinrl.core.agent
+
+fun interface TransitionObserver<State, Action> {
+    operator fun invoke(transition: Transition<State, Action>)
+}

--- a/core/src/main/kotlin/io/github/kotlinrl/core/algorithms/QTable.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/algorithms/QTable.kt
@@ -2,7 +2,6 @@ package io.github.kotlinrl.core.algorithms
 
 import org.apache.commons.csv.*
 import org.jetbrains.kotlinx.multik.api.*
-import org.jetbrains.kotlinx.multik.api.math.*
 import org.jetbrains.kotlinx.multik.ndarray.data.*
 import org.jetbrains.kotlinx.multik.ndarray.data.DataType.*
 import org.jetbrains.kotlinx.multik.ndarray.operations.*
@@ -25,7 +24,12 @@ class QTable(
 
     override fun maxValue(state: IntArray): Double = qValues(state).max() ?: 0.0
 
-    override fun bestAction(state: IntArray): Int = qValues(state).argMax()
+    override fun bestAction(state: IntArray): Int {
+        val q = qValues(state)
+        val max = q.max() ?: 0.0
+        val candidate = q.indices.filter { q[it] == max }
+        return candidate.random()
+    }
 
     fun copy(): QTable {
         val copy = QTable(*shape)
@@ -39,13 +43,16 @@ class QTable(
 
     override fun load(path: String) {
         val dn = mk.readCsvSafely(path)
-        table =  when (shape.size) {
+        val t =  when (shape.size) {
             2 -> dn.reshape(shape[0], shape[1])
             3 -> dn.reshape(shape[0], shape[1], shape[2])
             4 -> dn.reshape(shape[0], shape[1], shape[2], shape[3])
             else -> dn.reshape(shape[0], shape[1], shape[2], shape[3], *shape.copyOfRange(4, shape.size))
         }.asDNArray()
+        t.data.copyInto(table.data)
     }
+
+    fun print() = println(table)
 }
 
 private fun mk.writeCsvSafely(path: String, ndarray: NDArray<Double, DN>): Unit =

--- a/core/src/main/kotlin/io/github/kotlinrl/core/algorithms/dp/PolicyIteration.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/algorithms/dp/PolicyIteration.kt
@@ -30,7 +30,7 @@ class PolicyIteration<State, Action>(
                 for (s in states) {
                     val oldV = vTable[s]
                     val a = pTable[s]
-                    val (next, r) = transitionFunction(s, a)
+                    val (next, _, r) = transitionFunction(s, a)
                     val newV = r + gamma * vTable[next]
                     vTable[s] = newV
                     delta = max(delta, abs(oldV - newV))
@@ -42,7 +42,7 @@ class PolicyIteration<State, Action>(
             for (s in states) {
                 val oldAction = pTable[s]
                 val bestAction = stateActionListProvider(s).maxByOrNull { a ->
-                    val (next, r) = transitionFunction(s, a)
+                    val (next, _, r) = transitionFunction(s, a)
                     r + gamma * vTable[next]
                 } ?: oldAction
 

--- a/core/src/main/kotlin/io/github/kotlinrl/core/algorithms/dp/ValueIteration.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/algorithms/dp/ValueIteration.kt
@@ -23,7 +23,7 @@ class ValueIteration<State, Action>(
             for (s in states) {
                 val oldV = vTable[s]
                 val bestValue = stateActionListProvider(s).maxOfOrNull { a ->
-                    val (next, r) = transitionFunction(s, a)
+                    val (next, _, r) = transitionFunction(s, a)
                     r + gamma * vTable[next]
                 } ?: 0.0
 
@@ -36,7 +36,7 @@ class ValueIteration<State, Action>(
             val bestAction = stateActionListProvider(s)
                 .sortedWith(actionComparator)
                 .maxByOrNull { a ->
-                    val (next, r) = transitionFunction(s, a)
+                    val (next, _, r) = transitionFunction(s, a)
                     r + gamma * vTable[next]
                 } ?: error("No actions available for state $s")
             pTable[s] = bestAction

--- a/core/src/main/kotlin/io/github/kotlinrl/core/algorithms/mc/ConstantAlphaMonteCarloControl.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/algorithms/mc/ConstantAlphaMonteCarloControl.kt
@@ -13,7 +13,7 @@ class ConstantAlphaMonteCarloControl<State, Action>(
         val visited = mutableSetOf<Pair<State, Action>>() // Optional: first-visit only
         var G = 0.0
 
-        for ((s, a, r) in stats.trajectories.asReversed()) {
+        for ((s, a, r) in stats.transitions.asReversed()) {
             G = r + gamma * G
             val key = Pair(s, a)
 

--- a/core/src/main/kotlin/io/github/kotlinrl/core/algorithms/mc/OffPolicyMonteCarloControl.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/algorithms/mc/OffPolicyMonteCarloControl.kt
@@ -15,7 +15,7 @@ class OffPolicyMonteCarloControl<State, Action>(
         var G = 0.0
         var W = 1.0
 
-        for ((s, a, r) in stats.trajectories.asReversed()) {
+        for ((s, a, r) in stats.transitions.asReversed()) {
             G = gamma * G + r
 
             val key = Pair(s, a)

--- a/core/src/main/kotlin/io/github/kotlinrl/core/algorithms/mc/OnPolicyMonteCarloControl.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/algorithms/mc/OnPolicyMonteCarloControl.kt
@@ -14,7 +14,7 @@ class OnPolicyMonteCarloControl<State, Action>(
         val visited = mutableSetOf<Pair<State, Action>>()
         var G = 0.0
 
-        for ((s, a, r) in stats.trajectories.asReversed()) {
+        for ((s, a, r) in stats.transitions.asReversed()) {
             G = r + gamma * G
             val key = Pair(s, a)
 

--- a/core/src/main/kotlin/io/github/kotlinrl/core/algorithms/td/ExpectedSARSA.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/algorithms/td/ExpectedSARSA.kt
@@ -1,9 +1,8 @@
 package io.github.kotlinrl.core.algorithms.td
 
-import io.github.kotlinrl.core.QFunction
-import io.github.kotlinrl.core.agent.*
-import io.github.kotlinrl.core.algorithms.QTable
-import io.github.kotlinrl.core.policy.*
+import io.github.kotlinrl.core.*
+import io.github.kotlinrl.core.policy.PolicyProbabilities
+import io.github.kotlinrl.core.policy.StateActionListProvider
 
 class ExpectedSARSA<State, Action>(
     qTable: QFunction<State, Action>,
@@ -13,9 +12,9 @@ class ExpectedSARSA<State, Action>(
     private val policyProbabilities: PolicyProbabilities<State, Action>
 ) : TabularTDLearning<State, Action>(qTable, alpha, gamma) {
 
-    override fun invoke(trajectory: Trajectory<State, Action>) {
-        val (s, a, r, sPrime, terminated, truncated, _) = trajectory
-        val done = terminated || truncated
+    override fun invoke(transition: Transition<State, Action>) {
+        val (s, a, r, sPrime) = transition
+        val done = transition.done
         val currentValue = qTable[s, a]
 
         val expectedValue = if (done) {

--- a/core/src/main/kotlin/io/github/kotlinrl/core/algorithms/td/QLearning.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/algorithms/td/QLearning.kt
@@ -1,8 +1,6 @@
 package io.github.kotlinrl.core.algorithms.td
 
-import io.github.kotlinrl.core.QFunction
-import io.github.kotlinrl.core.agent.*
-import io.github.kotlinrl.core.algorithms.QTable
+import io.github.kotlinrl.core.*
 
 class QLearning<State, Action>(
     qTable: QFunction<State, Action>,
@@ -10,9 +8,9 @@ class QLearning<State, Action>(
     gamma: Double
 ) : TabularTDLearning<State, Action>(qTable, alpha, gamma) {
 
-    override fun invoke(trajectory: Trajectory<State, Action>) {
-        val (s, a, r, sPrime, terminated, truncated, _) = trajectory
-        val done = terminated || truncated
+    override fun invoke(transition: Transition<State, Action>) {
+        val (s, a, r, sPrime) = transition
+        val done = transition.done
 
         val currentValue = qTable[s, a]
         val nextValue = if (done) 0.0 else qTable.maxValue(sPrime)

--- a/core/src/main/kotlin/io/github/kotlinrl/core/algorithms/td/SARSA.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/algorithms/td/SARSA.kt
@@ -9,14 +9,14 @@ class SARSA<State, Action>(
 ) : TabularTDLearning<State, Action>(qTable, alpha, gamma) {
     private var action: Action? = null
 
-    override fun invoke(trajectory: Trajectory<State, Action>) {
+    override fun invoke(transition: Transition<State, Action>) {
         if (action == null) {
-            action = trajectory.action
+            action = transition.action
             return
         }
         val aPrime = action!!
-        val (s, a, r, sPrime, terminated, truncated, _) = trajectory
-        val done = terminated || truncated
+        val (s, a, r, sPrime) = transition
+        val done = transition.done
 
         val currentValue = qTable[s, a]
         val nextValue = if (done) 0.0 else qTable[sPrime, aPrime]

--- a/core/src/main/kotlin/io/github/kotlinrl/core/algorithms/td/TabularTDLearning.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/algorithms/td/TabularTDLearning.kt
@@ -6,6 +6,4 @@ abstract class TabularTDLearning<State, Action>(
     protected val qTable: QFunction<State, Action>,
     protected val alpha: Double,
     protected val gamma: Double
-) : TrajectoryObserver<State, Action> {
-
-}
+) : TransitionObserver<State, Action>

--- a/core/src/main/kotlin/io/github/kotlinrl/core/algorithms/td/nstep/NStepSARSA.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/algorithms/td/nstep/NStepSARSA.kt
@@ -1,0 +1,57 @@
+package io.github.kotlinrl.core.algorithms.td.nstep
+
+import io.github.kotlinrl.core.*
+import io.github.kotlinrl.core.train.EpisodeStats
+import kotlin.math.pow
+
+class NStepSARSA<State, Action>(
+    qTable: QFunction<State, Action>,
+    alpha: Double,
+    gamma: Double,
+    private val n: Int,
+    private val policyProbabilities: PolicyProbabilities<State, Action>
+) : TabularTDLearning<State, Action>(qTable, alpha, gamma), EpisodeCallback<State, Action> {
+
+    private val queue = ArrayDeque<Transition<State, Action>>(n)
+
+    override fun onEpisodeStart(episode: Int) {
+        queue.clear()
+    }
+
+    override fun onEpisodeEnd(stats: EpisodeStats<State, Action>) {
+        while (queue.isNotEmpty<Transition<State, Action>>()) {
+            update(queue.size)
+        }
+    }
+
+    override fun invoke(transition: Transition<State, Action>) {
+        queue.addLast(transition)
+        if (queue.size >= n) {
+            update(n)
+        }
+    }
+
+    private fun update(steps: Int) {
+        val transitions = queue.take(steps)
+        val (s0, a0) = transitions.first().state to transitions.first().action
+
+        var g = 0.0
+        for (i in transitions.indices) {
+            g += gamma.pow(i) * transitions[i].reward
+        }
+
+        val last = transitions.last()
+        if (!last.done) {
+            val expectedQ = policyProbabilities(last.state).entries.sumOf { (a, prob) ->
+                prob * qTable[last.state, a]
+            }
+            g += gamma.pow(transitions.size) * expectedQ
+        }
+
+        val currentQ = qTable[s0, a0]
+        qTable[s0, a0] = currentQ + alpha * (g - currentQ)
+
+        queue.removeFirst()
+    }
+
+}

--- a/core/src/main/kotlin/io/github/kotlinrl/core/env/Env.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/env/Env.kt
@@ -4,7 +4,7 @@ import io.github.kotlinrl.core.space.*
 import kotlin.random.*
 
 interface Env<State, Action, ObservationSpace : Space<State>, ActionSpace : Space<Action>> {
-    fun step(action: Action): Transition<State>
+    fun step(action: Action): StepResult<State>
     fun reset(seed: Int? = null, options: Map<String, String>? = null): InitialState<State>
     fun render(): Rendering
     fun close()

--- a/core/src/main/kotlin/io/github/kotlinrl/core/env/ModelBasedEnv.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/env/ModelBasedEnv.kt
@@ -5,5 +5,5 @@ import io.github.kotlinrl.core.*
 interface ModelBasedEnv<State, Action, ObservationSpace : Space<State>, ActionSpace : Space<Action>>
     : Env<State, Action, ObservationSpace, ActionSpace> {
 
-    fun simulateStep(state: State, action: Action): Transition<State>
+    fun simulateStep(state: State, action: Action): StepResult<State>
 }

--- a/core/src/main/kotlin/io/github/kotlinrl/core/env/StepResult.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/env/StepResult.kt
@@ -1,6 +1,6 @@
 package io.github.kotlinrl.core.env
 
-data class Transition<State>(
+data class StepResult<State>(
     val state: State,
     val reward: Double,
     val terminated: Boolean,

--- a/core/src/main/kotlin/io/github/kotlinrl/core/plan/TransitionFunction.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/plan/TransitionFunction.kt
@@ -3,5 +3,5 @@ package io.github.kotlinrl.core.plan
 import io.github.kotlinrl.core.*
 
 fun interface TransitionFunction<State, Action> {
-    operator fun invoke(state: State, action: Action): Transition<State>
+    operator fun invoke(state: State, action: Action): Transition<State, Action>
 }

--- a/core/src/main/kotlin/io/github/kotlinrl/core/train/EpisodeStats.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/train/EpisodeStats.kt
@@ -1,10 +1,10 @@
 package io.github.kotlinrl.core.train
 
-import io.github.kotlinrl.core.agent.*
+import io.github.kotlinrl.core.Transition
 
 data class EpisodeStats<State, Action>(
     val episode: Int,
     val totalReward: Double,
     val steps: Int,
-    val trajectories: List<Trajectory<State, Action>>,
+    val transitions: List<Transition<State, Action>>
 )

--- a/core/src/main/kotlin/io/github/kotlinrl/core/train/EpisodeTrainer.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/train/EpisodeTrainer.kt
@@ -1,7 +1,6 @@
 package io.github.kotlinrl.core.train
 
-import io.github.kotlinrl.core.agent.*
-import io.github.kotlinrl.core.env.*
+import io.github.kotlinrl.core.*
 
 class EpisodeTrainer<State, Action>(
     private val env: Env<State, Action, *, *>,
@@ -13,47 +12,45 @@ class EpisodeTrainer<State, Action>(
     override fun train(episodes: Int): TrainingResult {
         val episodeRewards = mutableListOf<Double>()
 
-        repeat(episodes) { episode ->
+        for(episode in 1 until episodes + 1) {
             callbacks.forEach { it.onEpisodeStart(episode) }
 
-            val trajectories = mutableListOf<Trajectory<State, Action>>()
+            val transitions = mutableListOf<Transition<State, Action>>()
             val actions = mutableListOf<Action>()
 
             var state = env.reset().state
             var totalReward = 0.0
-            var steps = 0
             var done = false
 
-            while (!done && steps < maxStepsPerEpisode) {
+            while (!done && transitions.size < maxStepsPerEpisode) {
                 val action = agent.act(state)
-                val transition = env.step(action)
-                totalReward += transition.reward
+                val stepResult = env.step(action)
+                totalReward += stepResult.reward
 
-                val trajectory = Trajectory(
+                val transition = Transition(
                     state = state,
                     action = action,
-                    nextState = transition.state,
-                    reward = transition.reward,
-                    terminated = transition.terminated,
-                    truncated = transition.truncated,
-                    info = transition.info
+                    nextState = stepResult.state,
+                    reward = stepResult.reward,
+                    terminated = stepResult.terminated,
+                    truncated = stepResult.truncated,
+                    info = stepResult.info
                 )
 
-                agent.observe(trajectory)
+                agent.observe(transition)
 
-                trajectories += trajectory
+                transitions += transition
                 actions += action
-                steps++
 
-                state = transition.state
-                done = transition.terminated || transition.truncated
+                state = transition.nextState
+                done = transition.done
             }
 
             val stats = EpisodeStats(
                 episode = episode,
                 totalReward = totalReward,
-                steps = steps,
-                trajectories = trajectories
+                steps = transitions.size,
+                transitions = transitions
             )
 
             callbacks.forEach { it.onEpisodeEnd(stats) }

--- a/core/src/main/kotlin/io/github/kotlinrl/core/train/TrainingResult.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/train/TrainingResult.kt
@@ -1,5 +1,7 @@
 package io.github.kotlinrl.core.train
 
 data class TrainingResult(
-    val episodeRewards: List<Double>
+    val episodeRewards: List<Double>,
+    val totalEpisodes: Int = episodeRewards.size,
+    val averageReward: Double = episodeRewards.average()
 )

--- a/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/ClipAction.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/ClipAction.kt
@@ -32,7 +32,7 @@ class ClipAction<
     override fun reset(seed: Int?, options: Map<String, String>?): InitialState<State> =
         env.reset(seed, options)
 
-    override fun step(action: NDArray<Num, D>): Transition<State> {
+    override fun step(action: NDArray<Num, D>): StepResult<State> {
         val clipped = clipToBox(action, env.actionSpace)
         return env.step(clipped)
     }

--- a/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/FilterAction.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/FilterAction.kt
@@ -30,7 +30,7 @@ class FilterAction<State, ObservationSpace : Space<State>>(
     override fun reset(seed: Int?, options: Map<String, String>?): InitialState<State> =
         env.reset(seed, options)
 
-    override fun step(action: Map<String, Any>): Transition<State> {
+    override fun step(action: Map<String, Any>): StepResult<State> {
         // Fill missing keys using default (or actionSpace.sample() if not provided)
         val fullAction = buildMap<String, Any> {
             // Agent-controlled keys

--- a/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/FilterObservation.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/FilterObservation.kt
@@ -34,7 +34,7 @@ class FilterObservation<Action, ActionSpace : Space<Action>>(
         )
     }
 
-    override fun step(action: Action): Transition<Map<String, Any>> {
+    override fun step(action: Action): StepResult<Map<String, Any>> {
         val t = env.step(action)
         return t.copy(state = filter(t.state))
     }

--- a/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/FlattenObservation.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/FlattenObservation.kt
@@ -47,10 +47,10 @@ class FlattenObservation<Num : Number, WrappedState, Action, WrappedObservationS
         )
     }
 
-    override fun step(action: Action): Transition<NDArray<Num, D1>> {
+    override fun step(action: Action): StepResult<NDArray<Num, D1>> {
         val t = env.step(action)
         val flat = toNDArray<Num>(flattenObservation(t.state, dtype), dtype)
-        return Transition(
+        return StepResult(
             state = flat,
             reward = t.reward,
             terminated = t.terminated,

--- a/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/Monitor.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/Monitor.kt
@@ -25,7 +25,7 @@ class Monitor<State, Action, ObservationSpace : Space<State>, ActionSpace : Spac
         return env.reset(seed, options)
     }
 
-    override fun step(action: Action): Transition<State> {
+    override fun step(action: Action): StepResult<State> {
         val t = env.step(action)
         episodeReward += t.reward
         episodeLength += 1

--- a/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/NormalizeReward.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/NormalizeReward.kt
@@ -13,7 +13,7 @@ class NormalizeReward<State, Action, ObservationSpace : Space<State>, ActionSpac
     override fun reset(seed: Int?, options: Map<String, String>?): InitialState<State> =
         env.reset(seed, options)
 
-    override fun step(action: Action): Transition<State> {
+    override fun step(action: Action): StepResult<State> {
         val t = env.step(action)
         stats.update(t.reward)
         val normalized = (t.reward - stats.mean) / maxOf(stats.std, epsilon)

--- a/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/NormalizeState.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/NormalizeState.kt
@@ -28,7 +28,7 @@ class NormalizeState<Num : Number, D : Dimension, Action, ObservationSpace : Spa
         return InitialState(state = normalize(initial.state), info = initial.info)
     }
 
-    override fun step(action: Action): Transition<NDArray<Num, D>> {
+    override fun step(action: Action): StepResult<NDArray<Num, D>> {
         val t = env.step(action)
         return t.copy(state = normalize(t.state))
     }

--- a/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/OrderEnforcing.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/OrderEnforcing.kt
@@ -14,7 +14,7 @@ class OrderEnforcing<State, Action, ObservationSpace : Space<State>, ActionSpace
         return env.reset(seed, options)
     }
 
-    override fun step(action: Action): Transition<State> {
+    override fun step(action: Action): StepResult<State> {
         if (needsReset) {
             throw IllegalStateException(
                 "step() called beforeStep reset(), or afterStep episode done. " +

--- a/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/RecordEpisodeStatistics.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/RecordEpisodeStatistics.kt
@@ -16,7 +16,7 @@ class RecordEpisodeStatistics<State, Action, ObservationSpace : Space<State>, Ac
         return env.reset(seed, options)
     }
 
-    override fun step(action: Action): Transition<State> {
+    override fun step(action: Action): StepResult<State> {
         val t = env.step(action)
         episodeReward += t.reward
         episodeLength += 1

--- a/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/RecordVideo.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/RecordVideo.kt
@@ -27,7 +27,7 @@ class RecordVideo<State, Action, ObservationSpace : Space<State>, ActionSpace : 
         return initial
     }
 
-    override fun step(action: Action): Transition<State> {
+    override fun step(action: Action): StepResult<State> {
         val t = env.step(action)
         if (record) {
             val rendering = env.render()

--- a/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/RescaleAction.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/RescaleAction.kt
@@ -28,7 +28,7 @@ class RescaleAction<State, Num : Number, D : Dimension, ObservationSpace : Space
     override fun reset(seed: Int?, options: Map<String, String>?): InitialState<State> =
         env.reset(seed, options)
 
-    override fun step(action: NDArray<Num, D>): Transition<State> {
+    override fun step(action: NDArray<Num, D>): StepResult<State> {
         val innerBox = env.actionSpace
         val scaled = rescale(
             x = action,

--- a/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/SimpleWrapper.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/SimpleWrapper.kt
@@ -7,7 +7,7 @@ open class SimpleWrapper<State, Action, ObservationSpace : Space<State>, ActionS
     env: Env<State, Action, ObservationSpace, ActionSpace>
 ) : Wrapper<State, Action, ObservationSpace, ActionSpace, State, Action, ObservationSpace, ActionSpace>(env) {
 
-    override fun step(action: Action): Transition<State> = env.step(action)
+    override fun step(action: Action): StepResult<State> = env.step(action)
 
     override fun reset(seed: Int?, options: Map<String, String>?): InitialState<State>  = env.reset(seed, options)
 

--- a/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/TimeLimit.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/TimeLimit.kt
@@ -15,7 +15,7 @@ class TimeLimit<State, Action, ObservationSpace : Space<State>, ActionSpace : Sp
         return env.reset(seed, options)
     }
 
-    override fun step(action: Action): Transition<State> {
+    override fun step(action: Action): StepResult<State> {
         val transition = env.step(action)
         elapsedSteps += 1
 

--- a/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/TransformReward.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/TransformReward.kt
@@ -5,11 +5,11 @@ import io.github.kotlinrl.core.space.*
 
 class TransformReward<State, Action, ObservationSpace : Space<State>, ActionSpace : Space<Action>>(
     env: Env<State, Action, ObservationSpace, ActionSpace>,
-    private val transform: (Double) -> Double
+    private val transform: (StepResult<State>) -> Double
 ) : SimpleWrapper<State, Action, ObservationSpace, ActionSpace>(env) {
 
-    override fun step(action: Action): Transition<State> {
-        val transition = env.step(action)
-        return transition.copy(reward = transform(transition.reward))
+    override fun step(action: Action): StepResult<State> {
+        val stepResult = env.step(action)
+        return stepResult.copy(reward = transform(stepResult))
     }
 }

--- a/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/TransformState.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/TransformState.kt
@@ -13,9 +13,9 @@ class TransformState<State, Action, ObservationSpace : Space<State>, ActionSpace
         return InitialState(state = transform(initial.state), info = initial.info)
     }
 
-    override fun step(action: Action): Transition<State> {
+    override fun step(action: Action): StepResult<State> {
         val transition = env.step(action)
-        return Transition(
+        return StepResult(
             state = transform(transition.state),
             reward = transition.reward,
             terminated = transition.terminated,

--- a/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/Wrapper.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/wrapper/Wrapper.kt
@@ -17,7 +17,7 @@ abstract class Wrapper<
     protected val env: Env<WrappedState, WrappedAction, WrappedObservationSpace, WrappedActionSpace>
 ) : Env<State, Action, ObservationSpace, ActionSpace> {
 
-    abstract override fun step(action: Action): Transition<State>
+    abstract override fun step(action: Action): StepResult<State>
 
     abstract override fun reset(seed: Int?, options: Map<String, String>?): InitialState<State>
 

--- a/envs/src/main/kotlin/io/github/kotlinrl/envs/Maze.kt
+++ b/envs/src/main/kotlin/io/github/kotlinrl/envs/Maze.kt
@@ -122,11 +122,11 @@ class Maze(
         }
     }
 
-    override fun step(action: Int): Transition<IntArray> {
+    override fun step(action: Int): StepResult<IntArray> {
         val reward = computeReward(state, action)
         state = nextState(state, action)
         val terminated = state.contentEquals(goal)
-        return Transition(state, reward, terminated, false, emptyMap())
+        return StepResult(state, reward, terminated, false, emptyMap())
     }
 
     override fun reset(seed: Int?, options: Map<String, String>?): InitialState<IntArray> {
@@ -237,10 +237,10 @@ class Maze(
         }
     }
 
-    override fun simulateStep(state: IntArray, action: Int): Transition<IntArray> {
+    override fun simulateStep(state: IntArray, action: Int): StepResult<IntArray> {
         val reward = computeReward(state, action)
         val nextState = nextState(state, action)
         val terminated = state.contentEquals(goal)
-        return Transition(nextState, reward, terminated, false, emptyMap())
+        return StepResult(nextState, reward, terminated, false, emptyMap())
     }
 }

--- a/integration/src/main/kotlin/io/github/kotlinrl/integration/gymnasium/RemoteEnvClient.kt
+++ b/integration/src/main/kotlin/io/github/kotlinrl/integration/gymnasium/RemoteEnvClient.kt
@@ -31,7 +31,7 @@ internal class RemoteEnvClient<State, Action, ObservationSpace : Space<State>, A
         )
     }
 
-    override fun step(action: Action): Transition<State> {
+    override fun step(action: Action): StepResult<State> {
         val (state, reward, terminated, truncated, info) = env.step(when(action) {
             is String -> action(action as String)
             is Int -> action(action as Int)
@@ -57,7 +57,7 @@ internal class RemoteEnvClient<State, Action, ObservationSpace : Space<State>, A
             )
             else -> TODO()
         })
-        return Transition(
+        return StepResult(
             state = state.toTypedState() as State,
             reward = reward,
             terminated = terminated,


### PR DESCRIPTION
…nal method signatures, rename `StepCallback`/`TrajectoryObserver` to `TransitionObserver`, update wrapper methods to return `StepResult`, and add NStepSARSA implementation. Remove deprecated `StepCallback` and `Trajectory`.