### PR TITLE
Refactor: Update `onEpisodeEnd` to use `TrainingResult` instead of `E…

### DIFF
--- a/core/src/main/kotlin/io/github/kotlinrl/core/Callbacks.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/Callbacks.kt
@@ -8,12 +8,14 @@ fun <State, Action> printEpisodeStart(
 
 fun <State, Action> printEpisodeTotalTransitions(
     printEvery: Int
-) : EpisodeCallback<State, Action> = onEpisodeEnd { stats ->
+) : EpisodeCallback<State, Action> = onEpisodeEnd { result ->
+    val stats = result.episodeStats.last()
     if (stats.episode % printEvery == 0)
         println("Finished episode ${stats.episode}, ${stats.trajectory.count()} transitions.")
 }
 
-fun <State, Action> printEpisodeOnGoalReached(printEvery: Int = 1) : EpisodeCallback<State, Action> = onEpisodeEnd { stats ->
+fun <State, Action> printEpisodeOnGoalReached(printEvery: Int = 1) : EpisodeCallback<State, Action> = onEpisodeEnd { result ->
+    val stats = result.episodeStats.last()
     if(stats.reachedGoal && stats.episode % printEvery == 0)
         println("Goal reached in episode ${stats.episode}.")
 }
@@ -25,7 +27,7 @@ fun <State, Action> onEpisodeStart(
 }
 
 fun <State, Action> onEpisodeEnd(
-    f: (stats: EpisodeStats<State, Action>) -> Unit
+    block: (result: TrainingResult) -> Unit
 ) : EpisodeCallback<State, Action> = object : EpisodeCallback<State, Action> {
-    override fun onEpisodeEnd(stats: EpisodeStats<State, Action>) = f(stats)
+    override fun onEpisodeEnd(result: TrainingResult) = block(result)
 }

--- a/core/src/main/kotlin/io/github/kotlinrl/core/train/EpisodeCallback.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/train/EpisodeCallback.kt
@@ -3,5 +3,5 @@ package io.github.kotlinrl.core.train
 interface EpisodeCallback<State, Action> {
     fun onEpisodeStart(episode: Int) {}
 
-    fun onEpisodeEnd(stats: EpisodeStats<State, Action>) {}
+    fun onEpisodeEnd(result: TrainingResult) {}
 }

--- a/core/src/main/kotlin/io/github/kotlinrl/core/train/EpisodeTrainer.kt
+++ b/core/src/main/kotlin/io/github/kotlinrl/core/train/EpisodeTrainer.kt
@@ -63,10 +63,10 @@ class EpisodeTrainer<State, Action>(
                 info = exception?.let { mapOf("exception" to it) } ?: emptyMap()
             )
             agent.observe(transitions, episode)
-            callbacks.forEach { it.onEpisodeEnd(stats) }
             episodeStats += stats
-
             val result = TrainingResult(episodeStats)
+            callbacks.forEach { it.onEpisodeEnd(result) }
+
             if (stopCondition(result)) {
                 if (closeOnSuccess) env.close()
                 return result


### PR DESCRIPTION
…pisodeStats` for improved callback consistency. Modify `EpisodeTrainer` to pass `TrainingResult` to callbacks.